### PR TITLE
FA-280 Adding Cosmos Permissions to the FrontEnd to receive and manage the Reports

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1304,6 +1304,16 @@ module appserviceOrchestratorAccess './core/host/functions-access.bicep' = {
   }
 }
 
+// Give the App Service access to Cosmos
+module appserviceCosmosAccess './core/security/cosmos-access.bicep' = {
+  name: 'appservice-cosmos-access'
+  scope: resourceGroup
+  params: {
+    principalId: frontEnd.outputs.identityPrincipalId
+    accountName: cosmosAccount.outputs.name
+  }
+}
+
 module dataIngestion './core/host/functions.bicep' = {
   name: 'dataIngestion'
   scope: resourceGroup


### PR DESCRIPTION
(FA-280)(https://salesfactoryai.atlassian.net/browse/FA-280)

Part of the Report management in all senses. Adding the permissions to the Webapp so the reports can be accessed, managed and deleted via the Webapp