### PR TITLE
create a companyAnalysis table in cosmos db

### DIFF
--- a/infra/core/db/cosmos.bicep
+++ b/infra/core/db/cosmos.bicep
@@ -7,6 +7,9 @@ param publicNetworkAccess string = 'Disabled'
 @description('Location for the Cosmos DB account.')
 param location string = resourceGroup().location
 
+@description('Minimum throughput for the Cosmos DB account.')
+param throughput int = 400
+
 param tags object = {}
 
 @description('The default consistency level of the Cosmos DB account.')
@@ -141,6 +144,40 @@ resource agentErrorsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabase
   }
 }
 
+resource companyAnalysisContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2022-05-15' = {
+  parent: database
+  name: 'companyAnalysis'
+  properties: {
+    resource: {
+      defaultTtl: 86400
+      id: 'companyAnalysis'
+      partitionKey: {
+        paths: [
+          '/id'
+        ]
+        kind: 'Hash'
+      }
+      analyticalStorageTtl: analyticalStoreTTL
+      indexingPolicy: {
+        indexingMode: 'consistent'
+        automatic: true
+        includedPaths: [
+          {
+            path: '/*'
+          }
+        ]
+        excludedPaths: [
+          {
+            path: '/"_etag"/?'
+          }
+        ]
+      }
+    }
+    options: {
+      throughput: throughput
+    }
+  }
+}
 resource conversationsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2022-05-15' = {
   parent: database
   name: containerName


### PR DESCRIPTION
This database table helps us track companies we want to analyze. By storing company names here, we can easily update, add, or remove companies from our reporting list.