### PR TITLE
Add storage container for FA-470-create-fa-container

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -382,7 +382,8 @@ param chunkTokenOverlap string = '200'
 // storage
 @description('Name of the container where source documents will be stored.')
 param storageContainerName string = 'documents'
-
+@description('Name of the container where financial agent documents will be stored.')
+param storageFinancialAgentContainerName string = 'FA_Documents'
 // Service names
 // The name for each service can be set from environment variables which are mapped in main.parameters.json.
 // Then no maping to specific name is defined, a unique name is generated for each service based on the resourceToken created above.
@@ -679,7 +680,10 @@ module storage './core/storage/storage-account.bicep' = {
     tags: tags
     publicNetworkAccess: networkIsolation ? 'Disabled' : 'Enabled'
     allowBlobPublicAccess: false // Disable anonymous access
-    containers: [{ name: containerName, publicAccess: 'None' }]
+    containers: [
+      { name: containerName, publicAccess: 'None' }
+      { name: storageFinancialAgentContainerName, publicAccess: 'None' }
+    ]
     keyVaultName: keyVault.outputs.name
     secretName: 'storageConnectionString'
     deleteRetentionPolicy: {


### PR DESCRIPTION
Financial Agent documents

- Create a new container in storage account for Financial Agent documents
- Add parameter for Financial Agent document container name
- Configure container with no public access

## JIRA Ticket
[FA-470](https://salesfactoryai.atlassian.net/jira/software/projects/FA/boards/1?selectedIssue=FA-470)

## Description
[Describe your changes here]

## Checklist
- [ ] Code review requested
- [ ] Tests completed
- [ ] Documentation updated