### PR TITLE
Update storage account references in Bicep templates for vision inges…

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -722,7 +722,7 @@ module visionIngestion './core/ai/vision-ingestion.bicep' = {
     location: 'westus' //Workaround for service availability
     tags: tags
     keyVaultName: keyVault.outputs.name
-    storageAccountName: storageAccountName
+    storageAccountName: storage.outputs.id
   }
 }
 
@@ -1499,7 +1499,7 @@ module deepseekR1Deployment 'core/ai/r1-deployment.bicep' = {
   params: {
     name: 'deepseekR1Deployment'
     keyVaultName: keyVault.outputs.name
-    storageAccountName: storageAccountName
+    storageAccountName: storage.outputs.id
   }
 }
 


### PR DESCRIPTION
…tion and deepseek R1 deployment

- Changed storageAccountName parameter to reference the storage outputs.id instead of the previous variable in both vision ingestion and deepseek R1 deployment modules.

## JIRA Ticket
[PROJ-XXX](link-to-ticket)

## Description
[Describe your changes here]

## Checklist
- [ ] Code review requested
- [ ] Tests completed
- [ ] Documentation updated