### PR TITLE
Add O1 deployment module and refactor cognitive services references

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -438,7 +438,9 @@ var openAiEndpoint = !empty(azureOpenAiEndpoint)
 param azureVnetName string = ''
 @description('Azure AI Vision Ingestion Service Name. Use your own name convention or leave as it is to generate a random name.')
 param azureVisionIngestionServiceName string = ''
-var visionIngestionServiceName = !empty(azureVisionIngestionServiceName) ? azureVisionIngestionServiceName : 'azai0-${resourceToken}'
+var visionIngestionServiceName = !empty(azureVisionIngestionServiceName)
+  ? azureVisionIngestionServiceName
+  : 'azai0-${resourceToken}'
 
 @description('Stripe API Key used by the orchestrator.')
 @secure()
@@ -1250,11 +1252,11 @@ module frontEnd 'core/host/appservice.bicep' = {
       }
       {
         name: 'O1_ENDPOINT'
-        value: openAi.outputs.o1Endpoint
+        value: o1Deployment.outputs.o1Endpoint
       }
       {
         name: 'O1_KEY'
-        value: openAi.outputs.o1Key
+        value: o1Deployment.outputs.o1Key
       }
     ]
   }
@@ -1556,6 +1558,28 @@ module openAi 'core/ai/cognitiveservices.bicep' = {
         sku: {
           name: 'Standard'
           capacity: embeddingsDeploymentCapacity
+        }
+      }
+    ]
+  }
+}
+
+module o1Deployment 'core/ai/o1-deployment.bicep' = {
+  name: 'o1Deployment'
+  scope: resourceGroup
+  params: {
+    name: 'o1Deployment'
+    keyVaultName: keyVault.outputs.name
+    secretsNames: {
+      secretName01: 'o1Key'
+    }
+    deployments: [
+      {
+        name: 'o1Deployment'
+        model: {
+          format: 'OpenAI'
+          name: 'o1-mini'
+          version: '2024-02-15-preview'
         }
       }
     ]


### PR DESCRIPTION
- Introduced a new Bicep module for O1 deployment, encapsulating the deployment logic for OpenAI models.
- Updated references in the main Bicep file to utilize outputs from the new O1 deployment module instead of the previous OpenAI module.
- Cleaned up the cognitive services Bicep file by removing unused parameters and outputs related to the O1 deployment.

## JIRA Ticket
[PROJ-XXX](link-to-ticket)

## Description
[Describe your changes here]

## Checklist
- [ ] Code review requested
- [ ] Tests completed
- [ ] Documentation updated