### PR TITLE
Function-app-agentic-search-role-requirements

### DIFF
--- a/infra/core/ai/cognitiveservices.bicep
+++ b/infra/core/ai/cognitiveservices.bicep
@@ -19,6 +19,9 @@ resource account 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
   location: location
   tags: tags
   kind: kind
+  identity: {
+    type: 'SystemAssigned'
+  }
   properties: {
     customSubDomainName: customSubDomainName
     publicNetworkAccess: publicNetworkAccess
@@ -62,3 +65,4 @@ resource keyVaultSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' =  [for s
 output endpoint string = account.properties.endpoint
 output id string = account.id
 output name string = account.name
+output principalId string = account.identity.principalId

--- a/infra/core/security/search-access.bicep
+++ b/infra/core/security/search-access.bicep
@@ -1,0 +1,39 @@
+param searchServiceName string
+param principalId string
+
+resource searchService 'Microsoft.Search/searchServices@2021-04-01-preview' existing = {
+  name: searchServiceName
+}
+
+// Search Service Contributor role
+resource searchServiceContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, searchService.id, principalId, 'search-service-contributor')
+  scope: searchService
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7ca78c08-252a-4471-8644-bb5ff32d4ba0') // Search Service Contributor role
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Search Index Data Contributor role
+resource searchIndexDataContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, searchService.id, principalId, 'search-index-data-contributor')
+  scope: searchService
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8ebe5a00-799e-43f5-93ac-243d3dce84a7') // Search Index Data Contributor role
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Search Index Data Reader role
+resource searchIndexDataReaderRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, searchService.id, principalId, 'search-index-data-reader')
+  scope: searchService
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '1407120a-92aa-4202-b7e9-c0e197c71c8f') // Search Index Data Reader role
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+} 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1110,6 +1110,16 @@ module orchestratorBlobStorageAccess './core/security/blobstorage-access-orc.bic
   }
 }
 
+// Give the orchestrator access to Azure AI Search
+module orchestratorSearchAccess './core/security/search-access.bicep' = {
+  name: 'orchestrator-agenticsearch-access'
+  scope: resourceGroup
+  params: {
+    searchServiceName: searchService.outputs.name
+    principalId: orchestrator.outputs.identityPrincipalId
+  }
+}
+
 module frontEnd 'core/host/appservice.bicep' = {
   name: 'frontend'
   scope: resourceGroup


### PR DESCRIPTION
This commit introduces a new module, `orchestratorSearchAccess`, in `main.bicep` to grant the orchestrator access to Azure AI Search. The module utilizes the `search-access.bicep` file and passes the necessary parameters, including the search service name and the orchestrator's principal ID, to ensure proper access control for the orchestrator's service principal.
