### PR TITLE
FA-789-deploy-a-new-Azure-function-to-host-MCP-servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .azdo
 local/
 venv/
+CLAUDE.md

--- a/azure.yaml
+++ b/azure.yaml
@@ -33,6 +33,18 @@ services:
           # this path is relative to ./.salesfactory/gpt-rag-orchestrator
           run: scripts/postdeploy.ps1
           interactive: false
+  mcpServer:
+    project: ./.salesfactory/freddAid-MCP-server
+    language: python
+    host: function
+    hooks:
+      postdeploy:
+        posix:
+          run: scripts/postdeploy.sh
+          interactive: false
+        windows:
+          run: scripts/postdeploy.ps1
+          interactive: false
   frontend:
     # backend is python and frontend is Vite app. The frontend is built with Vite settings to output into the backend's static folder.
     project: ./.salesfactory/gpt-rag-frontend/backend

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -412,6 +412,11 @@ param azureDataIngestionFunctionAppName string = ''
 var dataIngestionFunctionAppName = !empty(azureDataIngestionFunctionAppName)
   ? azureDataIngestionFunctionAppName
   : 'fninges0-${resourceToken}'
+@description('MCP server function name')
+param azureMcpServerFunctionAppName string = ''
+var mcpServerFunctionAppName = !empty(azureMcpServerFunctionAppName)
+  ? azureMcpServerFunctionAppName
+  : 'fnmcp-${resourceToken}'
 @description('Search Service Name. Use your own name convention or leave as it is to generate a random name.')
 param azureSearchServiceName string = ''
 var searchServiceName = !empty(azureSearchServiceName) ? azureSearchServiceName : 'search0-${resourceToken}'
@@ -1064,6 +1069,20 @@ module orchestratorPe './core/network/private-endpoint.bicep' = if (networkIsola
   }
 }
 
+module mcpServerPe './core/network/private-endpoint.bicep' = if (networkIsolation) {
+  name: 'mcpServerPe'
+  scope: resourceGroup
+  params: {
+    location: location
+    name: 'mcpServerPe${resourceToken}'
+    tags: tags
+    subnetId: vnet.outputs.aiSubId
+    serviceId: mcpServer.outputs.id
+    groupIds: ['sites']
+    dnsZoneId: networkIsolation ? websitesDnsZone.outputs.id : ''
+  }
+}
+
 // // B2C Tenant
 // module b2cTenant './core/identity/b2c.bicep' = {
 //   name: 'b2ctenant'
@@ -1137,6 +1156,56 @@ module orchestratorSearchAccess './core/security/search-access.bicep' = {
   params: {
     searchServiceName: searchService.outputs.name
     principalId: orchestrator.outputs.identityPrincipalId
+  }
+}
+
+// Give the MCP Resource Token function access to KeyVault
+module mcpServerKeyVaultAccess './core/security/keyvault-access.bicep' = {
+  name: 'mcp-server-keyvault-access'
+  scope: resourceGroup
+  params: {
+    keyVaultName: keyVault.outputs.name
+    principalId: mcpServer.outputs.identityPrincipalId
+  }
+}
+
+// Give the MCP Resource Token function access to Cosmos
+module mcpServerCosmosAccess './core/security/cosmos-access.bicep' = {
+  name: 'mcp-server-cosmos-access'
+  scope: resourceGroup
+  params: {
+    principalId: mcpServer.outputs.identityPrincipalId
+    accountName: cosmosAccount.outputs.name
+  }
+}
+
+// Give the MCP Resource Token function access to AOAI
+module mcpServerOaiAccess './core/security/openai-access.bicep' = {
+  name: 'mcp-server-openai-access'
+  scope: resourceGroup
+  params: {
+    principalId: mcpServer.outputs.identityPrincipalId
+    openaiAccountName: openAi.outputs.name
+  }
+}
+
+// Give the MCP Resource Token function access to blob storage with enhanced permissions
+module mcpServerBlobStorageAccess './core/security/blobstorage-access-orc.bicep' = {
+  name: 'mcp-server-blobstorage-access'
+  scope: resourceGroup
+  params: {
+    storageAccountName: storage.outputs.name
+    principalId: mcpServer.outputs.identityPrincipalId
+  }
+}
+
+// Give the MCP Resource Token function access to Azure AI Search
+module mcpServerSearchAccess './core/security/search-access.bicep' = {
+  name: 'mcp-server-agenticsearch-access'
+  scope: resourceGroup
+  params: {
+    searchServiceName: searchService.outputs.name
+    principalId: mcpServer.outputs.identityPrincipalId
   }
 }
 
@@ -1696,6 +1765,51 @@ module searchPe './core/network/private-endpoint.bicep' = if (networkIsolation) 
   }
 }
 
+module mcpServer './core/host/functions.bicep' = {
+  name: 'mcpServer'
+  scope: resourceGroup
+  params: {
+    keyVaultName: keyVault.outputs.name
+    appServicePlanId: appServicePlan.outputs.id
+    subnetId: vnet.outputs.appIntSubId
+    vnetName: vnet.outputs.name
+    networkIsolation: networkIsolation
+    storageAccountName: '${storageAccountName}mcp'
+    appName: mcpServerFunctionAppName
+    location: location
+    appInsightsConnectionString: appInsights.outputs.connectionString
+    appInsightsInstrumentationKey: appInsights.outputs.instrumentationKey
+    tags: union(tags, { 'azd-service-name': 'mcpServer' })
+    alwaysOn: true
+    allowedOrigins: ['*']
+    functionAppScaleLimit: 2
+    minimumElasticInstanceCount: 1
+    numberOfWorkers: 2
+    appSettings: [
+      {
+        name: 'PYTHON_ENABLE_INIT_INDEXING'
+        value: pythonEnableInitIndexing
+      }
+      {
+        name: 'ENABLE_ORYX_BUILD'
+        value: 'true'
+      }
+      {
+        name: 'SCM_DO_BUILD_DURING_DEPLOYMENT'
+        value: 'true'
+      }
+      {
+        name: 'AzureWebJobsFeatureFlags'
+        value: 'EnableWorkerIndexing'
+      }
+      {
+        name: 'LOGLEVEL'
+        value: 'INFO'
+      }
+    ]
+  }
+}
+
 output AZURE_KEY_VAULT_NAME string = keyVault.outputs.name
 output AZURE_ZERO_TRUST string = networkIsolation ? 'TRUE' : 'FALSE'
 output AZURE_VM_NAME string = networkIsolation ? ztVmName : ''
@@ -1707,6 +1821,8 @@ output AZURE_DATA_INGEST_FUNC_RG string = resourceGroup.name
 output AZURE_SEARCH_PRINCIPAL_ID string = searchService.outputs.principalId
 output AZURE_ORCHESTRATOR_FUNC_RG string = resourceGroup.name
 output AZURE_ORCHESTRATOR_FUNC_NAME string = orchestratorFunctionAppName
+output AZURE_MCPSERVER_FUNC_NAME string = mcpServerFunctionAppName
+output AZURE_MCPSERVER_FUNC_RG string = resourceGroup.name
 
 // Set input params as outputs to persist the selection
 // This strategy would allow to re-construct the .env file from a deployment object on azure by using env-name, sub and location.
@@ -1722,6 +1838,7 @@ output AZURE_APP_INSIGHTS_NAME string = azureAppInsightsName
 output AZURE_APP_SERVICE_NAME string = azureAppServiceName
 output AZURE_ORCHESTRATOR_FUNCTION_APP_NAME string = azureOrchestratorFunctionAppName
 output AZURE_DATA_INGESTION_FUNCTION_APP_NAME string = azureDataIngestionFunctionAppName
+output AZURE_MCP_SERVER_FUNCTION_APP_NAME string = azureMcpServerFunctionAppName
 output AZURE_SEARCH_SERVICE_NAME string = azureSearchServiceName
 output AZURE_OPEN_AI_SERVICE_NAME string = azureOpenAiServiceName
 output AZURE_VNET_NAME string = azureVnetName

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -80,6 +80,9 @@
     "azureDataIngestionFunctionAppName": {
       "value": "${AZURE_DATA_INGESTION_FUNCTION_APP_NAME}"
     },
+    "azureMcpServerFunctionAppName": {
+      "value": "${AZURE_MCP_SERVER_FUNCTION_APP_NAME}"
+    },
     "azureSearchServiceName": {
       "value": "${AZURE_SEARCH_SERVICE_NAME}"
     },

--- a/scripts/fetchComponents.sh
+++ b/scripts/fetchComponents.sh
@@ -23,3 +23,11 @@ fi
 
 # Clone the repository into the .salesfactory folder
 git clone -b develop https://github.com/Salesfactory/gpt-rag-frontend ./.salesfactory/gpt-rag-frontend
+
+# Delete the freddAid-MCP-server folder from .salesfactory if it exists
+if [ -d ./.salesfactory/freddAid-MCP-server ]; then
+    rm -rf ./.salesfactory/freddAid-MCP-server
+fi
+
+# Clone the freddAid-MCP-server repository into the .salesfactory folder
+git clone -b develop https://github.com/Salesfactory/freddAid-MCP-server ./.salesfactory/freddAid-MCP-server


### PR DESCRIPTION
- Added MCP server configuration in `azure.yaml` with post-deploy hooks for both POSIX and Windows.
- Introduced new parameters and modules in `main.bicep` for MCP server function, including access to KeyVault, Cosmos, OpenAI, and blob storage.
- Updated `main.parameters.json` to include MCP server function app name.
- Modified `.gitignore` to include `CLAUDE.md`.
- Enhanced `fetchComponents.sh` to clone the `freddAid-MCP-server` repository and clean up any existing folder.