### PR TITLE
Hot-fix--remove-redundant-api-version-var

### DIFF
--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -32,9 +32,6 @@
     "chatGptModelVersion": {
       "value": "0613"
     },
-    "openaiApiVersion": {
-      "value": "2024-05-01-preview"
-    },
     "orchestratorMessagesLanguage": {
       "value": "en"
     },


### PR DESCRIPTION
- Removed the outdated OpenAI API version parameter to streamline configuration and avoid confusion with the latest version updates.