### PR TITLE
Add-openai-user-role-to-orchestrator

### DIFF
--- a/infra/core/security/openai-access-rg.bicep
+++ b/infra/core/security/openai-access-rg.bicep
@@ -1,0 +1,15 @@
+param principalId string
+
+// Cognitive Services OpenAI User role assignment at resource group level
+// This grants access to all Cognitive Services/AI resources in the resource group
+resource openaiUserRoleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
+  name: guid(resourceGroup().id, principalId, 'cognitive-services-openai-user')
+  properties: {
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd'
+    ) // Cognitive Services OpenAI User
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1186,13 +1186,12 @@ module orchestratorCosmosAccess './core/security/cosmos-access.bicep' = {
   }
 }
 
-// Give the orchestrator access to AOAI
-module orchestratorOaiAccess './core/security/openai-access.bicep' = {
-  name: 'orchestrator-openai-access'
+// Give the orchestrator access to all AI resources in the resource group
+module orchestratorOaiAccess './core/security/openai-access-rg.bicep' = {
+  name: 'orchestrator-openai-access-rg'
   scope: resourceGroup
   params: {
     principalId: orchestrator.outputs.identityPrincipalId
-    openaiAccountName: openAi.outputs.name
   }
 }
 


### PR DESCRIPTION
- Updated the orchestrator's access to include all AI resources in the resource group by creating a new module `openai-access-rg.bicep`.
- This module assigns the Cognitive Services OpenAI User role to the orchestrator's service principal, enhancing its permissions for AI resource management.