### PR TITLE
Feat--Modify-token-size-for-ingestion

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -364,11 +364,11 @@ param azureSearchUseMIS bool = false
 
 // chunking
 @description('The number of tokens in each chunk.')
-param chunkNumTokens string = '2048'
+param chunkNumTokens string = '650'
 @description('The minimum chunk size below which chunks will be filtered.')
 param chunkMinSize string = '100'
 @description('The number of tokens to overlap between chunks.')
-param chunkTokenOverlap string = '200'
+param chunkTokenOverlap string = '125'
 
 // storage
 @description('Name of the container where source documents will be stored.')


### PR DESCRIPTION
- Changed chunkNumTokens from 2048 to 650 to optimize processing.
- Adjusted chunkTokenOverlap from 200 to 125 to improve efficiency in token management.