### PR TITLE
Add-required-roles-to-ingestion-function

### DIFF
--- a/infra/core/security/cognitive-services-user-access.bicep
+++ b/infra/core/security/cognitive-services-user-access.bicep
@@ -1,0 +1,23 @@
+param cognitiveServiceAccountName string
+param principalId string
+
+// Cognitive Services User role assignment for the specific AI services resource
+// This grants permission to use the Cognitive Services (including Document Intelligence)
+resource cognitiveServicesUserRoleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
+  name: guid(cognitiveServiceAccount.id, principalId, 'cognitive-services-user')
+  scope: cognitiveServiceAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      'a97b65f3-24c7-4388-baec-2e87135dc908'
+    ) // Cognitive Services User
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource cognitiveServiceAccount 'Microsoft.CognitiveServices/accounts@2023-05-01' existing = {
+  name: cognitiveServiceAccountName
+}
+
+output roleAssignmentId string = cognitiveServicesUserRoleAssignment.id

--- a/infra/core/security/contributor-rg-access.bicep
+++ b/infra/core/security/contributor-rg-access.bicep
@@ -1,0 +1,17 @@
+param principalId string
+
+// Contributor role assignment at resource group level
+// This grants permission to create and manage resources within the resource group
+resource contributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
+  name: guid(resourceGroup().id, principalId, 'contributor')
+  properties: {
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      'b24988ac-6180-42a0-ab88-20f7382dd24c'
+    ) // Contributor
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+output roleAssignmentId string = contributorRoleAssignment.id

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1290,6 +1290,25 @@ module mcpServerAiFoundryAccess './core/security/ai-foundry-access.bicep' = {
   }
 }
 
+// Assign Cognitive Services User role for the multi-service AI account to data ingestion function
+module cognitiveServicesUserAccess './core/security/cognitive-services-user-access.bicep' = {
+  name: 'data-ingestion-cognitive-services-user-access'
+  scope: resourceGroup
+  params: {
+    cognitiveServiceAccountName: cognitiveServices.outputs.name
+    principalId: dataIngestion.outputs.identityPrincipalId
+  }
+}
+
+// Assign Contributor role at resource group level to data ingestion function
+module contributorRgAccess './core/security/contributor-rg-access.bicep' = {
+  name: 'data-ingestion-contributor-rg-access'
+  scope: resourceGroup
+  params: {
+    principalId: dataIngestion.outputs.identityPrincipalId
+  }
+}
+
 module frontEnd 'core/host/appservice.bicep' = {
   name: 'frontend'
   scope: resourceGroup


### PR DESCRIPTION
- Introduced a new module for assigning the Cognitive Services User role to the data ingestion function, enabling access to AI services.
- Added a module for Contributor role assignment at the resource group level for the data ingestion function, allowing resource management capabilities.
- Updated the main Bicep file to include these new role assignment modules, enhancing the security and access control for the data ingestion process.