### PR TITLE
FA-997: remove companyAnalysis container from Cosmos DB Bicep file

### DIFF
--- a/infra/core/db/cosmos.bicep
+++ b/infra/core/db/cosmos.bicep
@@ -144,40 +144,6 @@ resource agentErrorsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabase
   }
 }
 
-resource companyAnalysisContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2022-05-15' = {
-  parent: database
-  name: 'companyAnalysis'
-  properties: {
-    resource: {
-      defaultTtl: 86400
-      id: 'companyAnalysis'
-      partitionKey: {
-        paths: [
-          '/id'
-        ]
-        kind: 'Hash'
-      }
-      analyticalStorageTtl: analyticalStoreTTL
-      indexingPolicy: {
-        indexingMode: 'consistent'
-        automatic: true
-        includedPaths: [
-          {
-            path: '/*'
-          }
-        ]
-        excludedPaths: [
-          {
-            path: '/"_etag"/?'
-          }
-        ]
-      }
-    }
-    options: {
-      throughput: throughput
-    }
-  }
-}
 resource conversationsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2022-05-15' = {
   parent: database
   name: containerName


### PR DESCRIPTION
- Deleted the companyAnalysis container resource definition to streamline the database configuration.
- Maintained existing configurations for the conversationsContainer resource.

## JIRA Ticket
[FA-997](https://salesfactoryai.atlassian.net/browse/FA-997)

## Description
[Describe your changes here]

## Checklist
- [ ] Code review requested
- [ ] Tests completed
- [ ] Documentation updated