### PR TITLE
Feature/add-openai-api-key-to-mcp-server

### DIFF
--- a/.github/workflows/dev-provision.yaml
+++ b/.github/workflows/dev-provision.yaml
@@ -80,6 +80,7 @@ jobs:
           AZURE_FUNCTIONS_WORKER_RUNTIME: "python"
           SERPER_API_KEY: ${{ secrets.SERPER_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           BRAND_ANALYSIS_MODEL: ${{ secrets.BRAND_ANALYSIS_MODEL }}
           REASONING_EFFORT: ${{ secrets.REASONING_EFFORT }}
 

--- a/.github/workflows/dev-validate-provision.yaml
+++ b/.github/workflows/dev-validate-provision.yaml
@@ -81,6 +81,7 @@ jobs:
           AZURE_FUNCTIONS_WORKER_RUNTIME: "python"
           SERPER_API_KEY: ${{ secrets.SERPER_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           BRAND_ANALYSIS_MODEL: ${{ secrets.BRAND_ANALYSIS_MODEL }}
           REASONING_EFFORT: ${{ secrets.REASONING_EFFORT }}
 

--- a/.github/workflows/prod-provision.yaml
+++ b/.github/workflows/prod-provision.yaml
@@ -80,6 +80,7 @@ jobs:
           AZURE_FUNCTIONS_WORKER_RUNTIME: "python"
           SERPER_API_KEY: ${{ secrets.SERPER_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           BRAND_ANALYSIS_MODEL: ${{ secrets.BRAND_ANALYSIS_MODEL }}
           REASONING_EFFORT: ${{ secrets.REASONING_EFFORT }}
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -552,6 +552,11 @@ var orchestratorTavilyApiKeyVar = !empty(orchestratorTavilyApiKey) ? orchestrato
 param orchestratorAnthropicApiKey string = ''
 var orchestratorAnthropicApiKeyVar = !empty(orchestratorAnthropicApiKey) ? orchestratorAnthropicApiKey : ''
 
+@description('OpenAI API Key used by the MCP server.')
+@secure()
+param mcpOpenAiApiKey string = ''
+var mcpOpenAiApiKeyVar = !empty(mcpOpenAiApiKey) ? mcpOpenAiApiKey : ''
+
 @description('Langsmith API Key for tracing')
 @secure()
 param langsmithApiKey string = ''
@@ -1921,6 +1926,10 @@ module mcpServer './core/host/functions.bicep' = {
       {
         name: 'ANTHROPIC_API_KEY'
         value: orchestratorAnthropicApiKeyVar
+      }
+      {
+        name: 'OPENAI_API_KEY'
+        value: mcpOpenAiApiKeyVar
       }
       {
         name: 'AZURE_SEARCH_INDEX'

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -149,6 +149,9 @@
     "orchestratorAnthropicApiKey": {
       "value": "${ANTHROPIC_API_KEY}"
     },
+    "mcpOpenAiApiKey": {
+      "value": "${OPENAI_API_KEY}"
+    },
     "orchestratorFunctionsWorkerRuntime": {
       "value": "${AZURE_FUNCTIONS_WORKER_RUNTIME}"
     },


### PR DESCRIPTION
- Add mcpOpenAiApiKey parameter and variable to main.bicep
  - Configure OPENAI_API_KEY environment variable for MCP server
  - Follow same secure parameter pattern as existing API keys
